### PR TITLE
Add JSON formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,26 @@ plug Logster.Plugs.ChangeLogLevel, to: :debug when action in [:index, :show]
 
 This is specially useful for cases such as when you want to lower the log level for a healthcheck endpoint that gets hit every few seconds.
 
+### Changing the formatter
+
+Logster allows you to use a different formatter to get your log lines looking just how you want. It comes with two built-in formatters: `Loggster.StringFormatter` and `Loggster.JSONFormatter`
+
+To use `Loggster.JSONFormatter`, supply the `formatter` option when you use the `Loggster.Plugs.Logger` plug:
+
+```elixir
+plug Loggster.Plugs.Logger, formatter: Loggster.JSONFormatter
+```
+
+That means your log messages will be formatted thusly:
+```
+{"status":200,"state":"set","path":"hello","params":{},"method":"GET","format":"json","duration":20.647,"controller":"App.HelloController","action":"show"
+```
+*Caution:* There is no guarantee that what reaches your console will be valid JSON. The Elixir `Logger` module has its own formatting which may be appended to your message. See the [Logger documentation](http://elixir-lang.org/docs/stable/logger/Logger.html) for more information.
+
+#### Writing your own formatter
+
+To write your own formatter, all that is required is a module which defines a `format/1` function, which accepts a keyword list and returns a string.
+
 ### License
 
 The MIT License

--- a/lib/logster/json_formatter.ex
+++ b/lib/logster/json_formatter.ex
@@ -1,0 +1,8 @@
+defmodule Logster.JSONFormatter do
+
+  def format(params) do
+    params
+    |> Enum.into(%{})
+    |> Poison.encode!
+  end
+end

--- a/lib/logster/plugs/logger.ex
+++ b/lib/logster/plugs/logger.ex
@@ -53,7 +53,7 @@ defmodule Logster.Plugs.Logger do
   defp current_time, do: :erlang.monotonic_time
   defp time_diff(start, stop), do: (stop - start) |> :erlang.convert_time_unit(:native, :micro_seconds)
 
-  defp formatted_duration(duration), do: duration / 1000 |> Float.to_string(decimals: 3)
+  defp formatted_duration(duration), do: duration / 1000
 
   defp formatted_phoenix_info(%{private: %{phoenix_format: format, phoenix_controller: controller, phoenix_action: action}}) do
     [

--- a/lib/logster/string_formatter.ex
+++ b/lib/logster/string_formatter.ex
@@ -1,0 +1,26 @@
+defmodule Logster.StringFormatter do
+
+  def format(params) do
+    params
+    |> Enum.map(&format_field/1)
+    |> Enum.intersperse(?\s)
+  end
+
+  defp format_field({key, value}) do
+    [to_string(key), "=", format_value(value)]
+  end
+
+  defp format_value(value) when is_binary(value) do
+    value
+  end
+
+  defp format_value(value) when is_atom(value) or is_integer(value) do
+    to_string(value)
+  end
+
+  defp format_value(value) when is_map(value) do
+    Poison.encode! value
+  end
+
+  
+end

--- a/lib/logster/string_formatter.ex
+++ b/lib/logster/string_formatter.ex
@@ -14,6 +14,10 @@ defmodule Logster.StringFormatter do
     value
   end
 
+  defp format_value(value) when is_float(value) do
+    Float.to_string(value, decimals: 3)
+  end
+
   defp format_value(value) when is_atom(value) or is_integer(value) do
     to_string(value)
   end
@@ -21,6 +25,4 @@ defmodule Logster.StringFormatter do
   defp format_value(value) when is_map(value) do
     Poison.encode! value
   end
-
-  
 end

--- a/test/logster/plugs/logger_test.exs
+++ b/test/logster/plugs/logger_test.exs
@@ -53,6 +53,23 @@ defmodule Logster.Plugs.LoggerTest do
     defp halter(conn, _), do: halt(conn)
   end
 
+  defmodule MyJSONPlug do
+    use Plug.Builder
+
+    plug Logster.Plugs.Logger,
+      formatter: Logster.JSONFormatter
+
+    plug Plug.Parsers,
+      parsers: [:urlencoded, :multipart, :json],
+      pass: ["*/*"],
+      json_decoder: Poison
+    plug :passthrough
+
+    defp passthrough(conn, _) do
+      Plug.Conn.send_resp(conn, 200, "Passthrough")
+    end
+  end
+
   defp capture_log(fun) do
     data = capture_io(:user, fn ->
       Process.put(:capture_log, fun.())
@@ -128,5 +145,15 @@ defmodule Logster.Plugs.LoggerTest do
     end
 
     assert message =~ "Logster.Plugs.LoggerTest.MyHaltingPlug halted in :halter/2"
+  end
+
+  test "logs to json with the JSONFormatter" do
+    {_conn, message} = capture_log fn ->
+      conn(:get, "/good") |> MyJSONPlug.call([])
+    end
+    json = message
+    |> String.split
+    |> Enum.at(3)
+    assert %{"path" =>  "/good"} = Poison.decode!(json)
   end
 end

--- a/test/logster/plugs/logger_test.exs
+++ b/test/logster/plugs/logger_test.exs
@@ -154,6 +154,8 @@ defmodule Logster.Plugs.LoggerTest do
     json = message
     |> String.split
     |> Enum.at(3)
-    assert %{"path" =>  "/good"} = Poison.decode!(json)
+    assert %{"path" =>  "/good"} = decoded = Poison.decode!(json)
+    %{"duration" => duration} = decoded
+    assert is_float(duration)
   end
 end


### PR DESCRIPTION
This adds a `:formatter` option to the plug, which lets you chose which
formatter you wish to use.

Formatting for the current format has been moved to `Logster.StringFormatter`
and a new `Logster.JSONFormatter` has been added to provide the JSON
formatting.

Still to do:
- [x]  Update Documentation
- [ ]  ???
