### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ def deps do
 end
 ```
 
+and add it to your list of applications:
+
+```elixir
+def application() do
+  [applications: [:logster]]
+end
+```
+
 Then, update your dependencies:
 
 ```


### PR DESCRIPTION
Add a note about adding `logster` to the list of applications. Otherwise `Logster` wouldn't be available in a release.

```
Request: GET /foo/bar
** (exit) an exception was raised:
    ** (UndefinedFunctionError) undefined function Logster.Plugs.Logger.call/2 (module Logster.Plugs.Logger is not available)
```
