### PR TITLE
Fixed deprecation warning

### DIFF
--- a/lib/logster/string_formatter.ex
+++ b/lib/logster/string_formatter.ex
@@ -15,7 +15,7 @@ defmodule Logster.StringFormatter do
   end
 
   defp format_value(value) when is_float(value) do
-    Float.to_string(value, decimals: 3)
+    :erlang.float_to_binary(value, [decimals: 3])
   end
 
   defp format_value(value) when is_atom(value) or is_integer(value) do


### PR DESCRIPTION
Float.to_string/2 is deprecated, changed to :erlang.float_to_binary/2
