### PR TITLE
HTTP Headers support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.4.0
+
+- Add HTTP header logging. Thanks to @zepplock
+
 # 0.3.0
 
 - Add custom metadata to the log. Thanks to @tanguyantoine

--- a/README.md
+++ b/README.md
@@ -66,6 +66,16 @@ You can update the list of parameters that are filtered by adding the following 
 config :logster, :filter_parameters, ["password", "secret", "token"]
 ```
 
+### HTTP headers support
+
+By default, Logster won't parse and log HTTP headers.
+
+But you can update the list of headers that should be parsed and logged. The logged headers will be added under `headers`. Both plain text and JSON formatters are supported.
+
+```elixir
+config :logster, :allowed_headers, ["my-header-one", "my-header-two"]
+```
+
 ### Changing the log level for a specific controller/action
 
 To change the Logster log level for a specific controller and/or action, you use the `Logster.Plugs.ChangeLogLevel` plug.

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Logster.Mixfile do
 
   def project do
     [app: :logster,
-     version: "0.3.0",
+     version: "0.4.0",
      name: "Logster",
      description: "Easily parsable log output for Plug and Phoenix applications",
      package: package,


### PR DESCRIPTION
- Non-intrusive, if no headers configured (by default) - won't parse and add more data to logs
- Tests
- Readme, chengelog, etc
