### PR TITLE
Add custom fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,27 @@ Custom metadata can be added using `Logger.metadata` such as:
 Logger.metadata(%{user_id: "123", foo: "bar"})
 ```
 
+### Add custom fields
+
+If additional fields other than the standard fields are desired, provide a module with a custom_fields/1 function which takes a conn and returns a list of keywords. Define a module like the following:
+```elixir
+defmodule MyCustomFields do
+  def custom_fields(conn) do
+    []
+    |> Keyword.put(:scheme, conn.scheme)
+    |> Keyword.put(:host, conn.host)
+  end
+end
+```
+Declare you plug to use the custom fields module:
+```elixir
+plug Logster.Plugs.Logger, custom_fields: MyCustomFields
+```
+This will produce output similar to the following:
+```
+state=set duration=3.881 status=200 params={} path=/foo method=GET host=www.example.com scheme=http
+```
+
 #### Writing your own formatter
 
 To write your own formatter, all that is required is a module which defines a `format/1` function, which accepts a keyword list and returns a string.

--- a/lib/logster/plugs/logger.ex
+++ b/lib/logster/plugs/logger.ex
@@ -35,6 +35,7 @@ defmodule Logster.Plugs.Logger do
     Conn.register_before_send(conn, fn conn ->
       Logger.log log_level(conn, opts), fn ->
         formatter = Keyword.get(opts, :formatter, Logster.StringFormatter)
+        custom_fields = Keyword.get(opts, :custom_fields, __MODULE__)
         stop_time = current_time()
         duration = time_diff(start_time, stop_time)
         []
@@ -47,10 +48,15 @@ defmodule Logster.Plugs.Logger do
         |> Keyword.put(:state, conn.state)
         |> Keyword.merge(headers(conn.req_headers, Application.get_env(:logster, :allowed_headers, @default_allowed_headers)))
         |> Keyword.merge(Logger.metadata())
+        |> Keyword.merge(custom_fields.custom_fields(conn))
         |> formatter.format
       end
       conn
     end)
+  end
+
+  def custom_fields(_) do
+    []
   end
 
   defp headers(_, []), do: []

--- a/lib/logster/plugs/logger.ex
+++ b/lib/logster/plugs/logger.ex
@@ -82,6 +82,7 @@ defmodule Logster.Plugs.Logger do
   end
   defp formatted_phoenix_info(_), do: []
 
+  defp get_params(%{params: _params = %Plug.Conn.Unfetched{}}), do: %{}
   defp get_params(%{params: params}) do
     params
     |> do_filter_params(Application.get_env(:logster, :filter_parameters, @default_filter_parameters))


### PR DESCRIPTION
I wanted to add some custom fields to my web log that were not included in the default fields in the Logster.Plugs.Logger.call function. I didn't want to have to modify this function as I might want to add other fields later. So I created a mechanism to include custom fields in the log that are not included in the default fields.

I added the ability to specify a custom fields module which will add whatever data is desired from the connection. The custom fields module only needs to expose a custom_fields function that takes a connection.

For example this is my current custom fields module I'm using in production:

```elixir
defmodule BrainLogCustomFields do
  def custom_fields(conn) do
    []
    |> Keyword.put(:remote_ip, remote_ip(conn))
    |> Keyword.put(:host, conn.host)
  end

  defp remote_ip(conn) do
    case conn.remote_ip do
      nil -> ""
      ip -> to_string(:inet_parse.ntoa(ip))
    end
  end
end
```

Then to include this module I define this in the website EndPoint module:
```elixir
  plug Logster.Plugs.Logger,
    formatter: BrainLogFormatter,
    custom_fields: BrainLogCustomFields
```

I've had this running in production for a few weeks and I'm happy with it.

Please note: I added a fix in logger.ex at line 85:
```elixir
defp get_params(%{params: _params = %Plug.Conn.Unfetched{}}), do: %{}
```
This handles when the logster plug is placed before Plug.Static. I want to log calls to static files as well, and the conn params are not fetched at that point.

I added to the documentation how to use the custom fields module.

Thank you for this plug, it has been very helpful.

Of course, you might prefer this is done in some other way or not want it included in the main plug which is cool.

If you have any questions or suggestions, please let me know.

Thank you,
Nathan Fox
