### PR TITLE
Adding default fields renaming feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,10 +120,10 @@ Logger.metadata(%{user_id: "123", foo: "bar"})
 
 ### Renaming default fields
 
-You can rename the default keys passing a list of `{:key, :new_key}` tuples:
+You can rename the default keys passing a map like `%{key: :new_key}`:
 
 ```elixir
-plug Logster.Plugs.Logger, renames: [{:duration, :response_time}, {:params, :parameters}]
+plug Logster.Plugs.Logger, renames: %{duration: :response_time, params: :parameters}
 ```
 It will log the following:
 ```

--- a/README.md
+++ b/README.md
@@ -118,6 +118,18 @@ Custom metadata can be added using `Logger.metadata` such as:
 Logger.metadata(%{user_id: "123", foo: "bar"})
 ```
 
+### Renaming default fields
+
+You can rename the default keys passing a list of `{:key, :new_key}` tuples:
+
+```elixir
+plug Logster.Plugs.Logger, renames: [{:duration, :response_time}, {:params, :parameters}]
+```
+It will log the following:
+```
+[info] method=GET path=/articles/some-article format=html controller=HelloPhoenix.ArticleController action=show parameters={"id":"some-article"} status=200 response_time=0.402 state=set
+```
+
 #### Writing your own formatter
 
 To write your own formatter, all that is required is a module which defines a `format/1` function, which accepts a keyword list and returns a string.

--- a/lib/logster/plugs/logger.ex
+++ b/lib/logster/plugs/logger.ex
@@ -35,22 +35,34 @@ defmodule Logster.Plugs.Logger do
     Conn.register_before_send(conn, fn conn ->
       Logger.log log_level(conn, opts), fn ->
         formatter = Keyword.get(opts, :formatter, Logster.StringFormatter)
+        renames = Keyword.get(opts, :renames, [])
         stop_time = current_time()
         duration = time_diff(start_time, stop_time)
         []
-        |> Keyword.put(:method, conn.method)
-        |> Keyword.put(:path, conn.request_path)
+        |> put_field(:method, renames, conn.method)
+        |> put_field(:path, renames, conn.request_path)
         |> Keyword.merge(formatted_phoenix_info(conn))
-        |> Keyword.put(:params, get_params(conn))
-        |> Keyword.put(:status, conn.status)
-        |> Keyword.put(:duration, formatted_duration(duration))
-        |> Keyword.put(:state, conn.state)
+        |> put_field(:params, renames, get_params(conn))
+        |> put_field(:status, renames, conn.status)
+        |> put_field(:duration, renames, formatted_duration(duration))
+        |> put_field(:state, renames, conn.state)
         |> Keyword.merge(headers(conn.req_headers, Application.get_env(:logster, :allowed_headers, @default_allowed_headers)))
         |> Keyword.merge(Logger.metadata())
         |> formatter.format
       end
       conn
     end)
+  end
+
+  defp put_field(keyword, default_key, renames, value) do
+    case Enum.find(renames, fn ({key, _new_key}) ->
+      key == default_key
+    end) do
+        {_default_key, new_key} ->
+          Keyword.put(keyword, new_key, value)
+        nil ->
+          Keyword.put(keyword, default_key, value)
+    end
   end
 
   defp headers(_, []), do: []

--- a/lib/logster/plugs/logger.ex
+++ b/lib/logster/plugs/logger.ex
@@ -35,7 +35,7 @@ defmodule Logster.Plugs.Logger do
     Conn.register_before_send(conn, fn conn ->
       Logger.log log_level(conn, opts), fn ->
         formatter = Keyword.get(opts, :formatter, Logster.StringFormatter)
-        renames = Keyword.get(opts, :renames, [])
+        renames = Keyword.get(opts, :renames, %{})
         stop_time = current_time()
         duration = time_diff(start_time, stop_time)
         []
@@ -55,14 +55,7 @@ defmodule Logster.Plugs.Logger do
   end
 
   defp put_field(keyword, default_key, renames, value) do
-    case Enum.find(renames, fn ({key, _new_key}) ->
-      key == default_key
-    end) do
-        {_default_key, new_key} ->
-          Keyword.put(keyword, new_key, value)
-        nil ->
-          Keyword.put(keyword, default_key, value)
-    end
+    Keyword.put(keyword, Map.get(renames, default_key, default_key), value)
   end
 
   defp headers(_, []), do: []

--- a/test/logster/plugs/logger_test.exs
+++ b/test/logster/plugs/logger_test.exs
@@ -74,7 +74,7 @@ defmodule Logster.Plugs.LoggerTest do
     use Plug.Builder
 
     plug Logster.Plugs.Logger,
-      renames: [{:status, :mystatus}, {:duration, :responsetime}]
+      renames: %{duration: :responsetime, status: :mystatus}
     plug Plug.Parsers,
       parsers: [:urlencoded, :multipart, :json],
       pass: ["*/*"],
@@ -207,7 +207,7 @@ defmodule Logster.Plugs.LoggerTest do
     assert message =~ "custom_metadata=OK"
   end
 
-  test "Renaming fields" do
+  test "renaming fields" do
     {_conn, message} = capture_log fn ->
       conn(:get, "/foo") |> MyRenameFieldsPlug.call([])
     end

--- a/test/logster/plugs/logger_test.exs
+++ b/test/logster/plugs/logger_test.exs
@@ -70,6 +70,22 @@ defmodule Logster.Plugs.LoggerTest do
     end
   end
 
+  defmodule MyRenameFieldsPlug do
+    use Plug.Builder
+
+    plug Logster.Plugs.Logger,
+      renames: [{:status, :mystatus}, {:duration, :responsetime}]
+    plug Plug.Parsers,
+      parsers: [:urlencoded, :multipart, :json],
+      pass: ["*/*"],
+      json_decoder: Poison
+    plug :passthrough
+
+    defp passthrough(conn, _) do
+      Plug.Conn.send_resp(conn, 200, "Passthrough")
+    end
+  end
+
   defmodule MyCustomLogMetadata do
     use Plug.Builder
     plug Logster.Plugs.Logger
@@ -189,6 +205,15 @@ defmodule Logster.Plugs.LoggerTest do
       conn(:get, "/good") |> MyCustomLogMetadata.call([])
     end
     assert message =~ "custom_metadata=OK"
+  end
+
+  test "Renaming fields" do
+    {_conn, message} = capture_log fn ->
+      conn(:get, "/foo") |> MyRenameFieldsPlug.call([])
+    end
+
+    assert message =~ "mystatus=200"
+    assert message =~ ~r/responsetime=\d+.\d{3}/u
   end
 
   test "[TextFormatter] log headers: no default headers, no output" do


### PR DESCRIPTION
I want to rename keys to get it working with my other web apps.

You can rename the default keys passing a list of `{:key, :new_key}` tuples:

```elixir
plug Logster.Plugs.Logger, renames: [{:duration, :response_time}, {:params, :parameters}]
```
It will log the following:
```
[info] method=GET path=/articles/some-article format=html controller=HelloPhoenix.ArticleController action=show parameters={"id":"some-article"} status=200 response_time=0.402 state=set
```