### PR TITLE
allows integration with openapispex

### DIFF
--- a/lib/logster/plugs/logger.ex
+++ b/lib/logster/plugs/logger.ex
@@ -136,6 +136,8 @@ defmodule Logster.Plugs.Logger do
 
   def do_filter_params(other, _params_to_filter), do: other
 
+  def do_format_values(%_{} = params), do: params |> Map.from_struct() |> do_format_values()
+
   def do_format_values(%{} = params), do: params |> Enum.into(%{}, &do_format_value/1)
 
   def do_format_value({key, value}) when is_binary(value) do


### PR DESCRIPTION
some tools like https://github.com/open-api-spex/open_api_spex convert Conn.params into a custom struct, this change allows to integrate with this type of tools by converting the struct back into a map