### PR TITLE
Improve remote_ip format, especially with ipv6

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ defmodule HelloPhoenix.SetLoggerMetadata do
     conn
   end
 
-  defp format_ip(%{remote_ip: remote_ip}) when remote_ip != nil, do: remote_ip |> Tuple.to_list |> Enum.join(".")
+  defp format_ip(%{remote_ip: remote_ip}) when remote_ip != nil, do: :inet_parse.ntoa(remote_ip)
   defp format_ip(_), do: nil
 
   defp get_user_id(%{assigns: %{current_user: %{id: id}}}), do: id


### PR DESCRIPTION
There's an Erlang function that converts an ipv4 or ipv6 address into a string, which gives a more compact output, especially when the addresses are ipv6.