### PR TITLE
don't blow up if passed an unexpected value

### DIFF
--- a/lib/logster/string_formatter.ex
+++ b/lib/logster/string_formatter.ex
@@ -13,5 +13,5 @@ defmodule Logster.StringFormatter do
   defp format_value(value) when is_float(value), do: :erlang.float_to_binary(value, decimals: 3)
   defp format_value(value) when is_atom(value) or is_integer(value), do: to_string(value)
   defp format_value(value) when is_map(value), do: Jason.encode!(value)
-  defp format_value(_), do: "(unprintable)"
+  defp format_value(value), do: inspect(value)
 end

--- a/lib/logster/string_formatter.ex
+++ b/lib/logster/string_formatter.ex
@@ -13,4 +13,5 @@ defmodule Logster.StringFormatter do
   defp format_value(value) when is_float(value), do: :erlang.float_to_binary(value, decimals: 3)
   defp format_value(value) when is_atom(value) or is_integer(value), do: to_string(value)
   defp format_value(value) when is_map(value), do: Jason.encode!(value)
+  defp format_value(_), do: "(unprintable)"
 end


### PR DESCRIPTION
After upgrading to Phoenix 1.5 and enabling the live dashboard, I started seeing `no function clause matching` errors when the StringFormatter received a tuple.  This PR adds a safe fallback if the value passed in is not an expected shape.