### PR TITLE
No longer raises an error if a map can not be encoded in JSON

### DIFF
--- a/lib/logster/string_formatter.ex
+++ b/lib/logster/string_formatter.ex
@@ -12,6 +12,13 @@ defmodule Logster.StringFormatter do
   defp format_value(value) when is_binary(value), do: value
   defp format_value(value) when is_float(value), do: :erlang.float_to_binary(value, decimals: 3)
   defp format_value(value) when is_atom(value) or is_integer(value), do: to_string(value)
-  defp format_value(value) when is_map(value), do: Jason.encode!(value)
+
+  defp format_value(value) when is_map(value) do
+    case Jason.encode(value) do
+      {:ok, json} -> json
+      {:error, _} -> inspect(value)
+    end
+  end
+
   defp format_value(value), do: inspect(value)
 end


### PR DESCRIPTION
Logging raising errors is problematic - it can mask real errors or break things if the logging level is changed.

Some things are not (by default) encodable with Jason. This falls back to using `inspect/1` should a `Map` not be encodable using the string formatter.