### PR TITLE
Fixed warning deprecation warnings

### DIFF
--- a/lib/logster/plugs/logger.ex
+++ b/lib/logster/plugs/logger.ex
@@ -152,6 +152,6 @@ defmodule Logster.Plugs.Logger do
   defp log_level(%{private: %{logster_log_level: log_level}}, _opts), do: log_level
   defp log_level(_, log: log_level), do: log_level
   defp log_level(%{status: status}, _opts) when status >= 500, do: :error
-  defp log_level(%{status: status}, _opts) when status >= 400, do: :warn
+  defp log_level(%{status: status}, _opts) when status >= 400, do: :warning
   defp log_level(_, _opts), do: :info
 end


### PR DESCRIPTION
The `warn` log level is deprecated, instead `warning` should be used