### PR TITLE
add ability to log all the headers and exclude some of the keys

### DIFF
--- a/test/logster/plug_test.exs
+++ b/test/logster/plug_test.exs
@@ -282,4 +282,31 @@ defmodule Logster.PlugTest do
     refute headers["my-header-two"]
     refute headers["my-header-three"]
   end
+
+  @tag with_config: [filter_headers: ["my-header-one"]]
+  test "[String] log headers with filtering by key" do
+    message =
+      conn(:post, "/hello/world", [])
+      |> put_req_header("my-header-one", "test-value-1")
+      |> put_req_header("my-header-two", "test-value-2")
+      |> call_and_capture_log(MyPlug)
+
+    refute message =~ ~s("test-value-1")
+    assert message =~ ~s("test-value-2")
+  end
+
+  @tag with_config: [
+         headers: ["my-header-one", "my-header-two"],
+         filter_headers: ["my-header-one"]
+       ]
+  test "[String] log only specified headers even with filter_headers settings" do
+    message =
+      conn(:post, "/hello/world", [])
+      |> put_req_header("my-header-one", "test-value-1")
+      |> put_req_header("my-header-two", "test-value-2")
+      |> call_and_capture_log(MyPlug)
+
+    assert message =~ ~s("test-value-1")
+    assert message =~ ~s("test-value-2")
+  end
 end

--- a/test/logster_test.exs
+++ b/test/logster_test.exs
@@ -945,6 +945,22 @@ defmodule Logster.Test do
       assert {:headers, %{"host" => "example.com", "accept" => "text/html"}} in fields
     end
 
+    @tag with_config: [filter_headers: ["content-type"]]
+    test "adds all the headers excluding specified" do
+      fields =
+        %Plug.Conn{
+          state: :set_chunked,
+          req_headers: [
+            {"content-type", "application/json"},
+            {"host", "example.com"},
+            {"accept", "text/html"}
+          ]
+        }
+        |> Logster.get_conn_fields(0)
+
+      assert {:headers, %{"host" => "example.com", "accept" => "text/html"}} in fields
+    end
+
     @tag with_config: [extra_fields: [:host]]
     test "includes host when enabled in config" do
       fields =


### PR DESCRIPTION
Example

```elixir
config :logster, :filter_headers: ["authorization"]
```